### PR TITLE
Let the Jackal respawn as Sidekick if there lives another Jackal and Sidekick spawn as Jackal if no more Jackal alive

### DIFF
--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -291,11 +291,24 @@ function plymeta:SpawnForRound(dead_only)
    if self:Team() == TEAM_SPEC then
       self:UnSpectate()
    end
-
+	
+   	--respawn as Sidekick if he was a Jackal and another Jackal exists
+	jackalCount = 0
+	for k,v in pairs(player.GetAll()) do
+		if(v:GetRole() == ROLE_JACKAL && v:Alive()) then
+			jackalCount = jackalCount + 1
+		end
+	end
+	
+	if(self:GetRole() == ROLE_JACKAL && jackalCount > 0) then
+		self:SetRole(ROLE_SIDEKICK)
+		SendFullStateUpdate()
+	end
+	
    self:StripAll()
    self:SetTeam(TEAM_TERROR)
    self:Spawn()
-
+	
    -- tell caller that we spawned
    return true
 end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -305,6 +305,11 @@ function plymeta:SpawnForRound(dead_only)
 		SendFullStateUpdate()
 	end
 	
+	if(self:GetRole() == ROLE_SIDEKICK && jackalCount == 0) then
+		self:SetRole(ROLE_JACKAL)
+		SendFullStateUpdate()
+	end
+	
    self:StripAll()
    self:SetTeam(TEAM_TERROR)
    self:Spawn()


### PR DESCRIPTION
 (i.e. through Defibrillator)

A revive through Second Change is not affected since the Sidekick won't turn into a Jackal in the mean time.